### PR TITLE
Instrument `exec_params` to support Rails 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 # 1.3.0
 
 - Use prepend to instrument Postgres queries `alias_method_chain` - [#8](https://github.com/peek/peek-pg/pull/5) [@8398a7](https://github.com/8398a7)
+
+# Next
+
+- Instrument `exec_params` to support Rails 5.1.

--- a/lib/peek/views/pg.rb
+++ b/lib/peek/views/pg.rb
@@ -29,6 +29,15 @@ module Peek
       ::PG::Connection.query_time.update { |value| value + duration }
       ::PG::Connection.query_count.update { |value| value + 1 }
     end
+
+    def exec_params(*args)
+      start = Time.now
+      super(*args)
+    ensure
+      duration = (Time.now - start)
+      ::PG::Connection.query_time.update { |value| value + duration }
+      ::PG::Connection.query_count.update { |value| value + 1 }
+    end
   end
 end
 


### PR DESCRIPTION
Rails 5.1 and later replace calls to `async_exec` to `exec_params`, for
better compatibility with the pg gem.

See https://github.com/rails/rails/pull/33188.